### PR TITLE
Issue #31: Fix deprication warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Die Dokumentation findet man unter: <http://jekyllbootstrap.com>
 
 Ein Jekyll Server kann einfach im Root Verzeichnis gestartet werden.
 ```bash
-$ jekyll serve
+$ jekyll serve -w
 ```
 
 ## Template

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,6 @@
 permalink: /:categories/:year/:month/:day/:title 
 
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
-auto: true
 pygments: true
 
 # Themes are encouraged to use these universal variables 


### PR DESCRIPTION
Removed 'auto'-option and edited command to start Jekyll in the readme.
