### PR TITLE
Issue #32: fix Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -133,7 +133,7 @@ end # task :page
 
 desc "Launch preview environment"
 task :preview do
-  system "jekyll --auto --server"
+  system "jekyll serve -w"
 end # task :preview
 
 # Public: Alias - Maintains backwards compatability for theme switching.


### PR DESCRIPTION
Changed rake task to launch jekyll preview to use subcommand to start serving using the watch-switch.

Note that if you don't merge issue #31 first, there will still be a warning thrown for "rake preview", as the fix for that in _config.yml wouldn't be made yet.

Hmm, what would be the best practice in order to avoid this dependency?
